### PR TITLE
Fixed Email field placeholder is missing from register page #207

### DIFF
--- a/frontend/src/components/SignupComponents/Main.js
+++ b/frontend/src/components/SignupComponents/Main.js
@@ -155,7 +155,7 @@ export default function Main() {
 <hr></hr>
 <form className='mt-6 relative'>
   <Input onSetData={setSignUpData} name='name' text='Name' placeholder='Enter your name' type='text'></Input>
-  <Input onSetData={setSignUpData} name='email' text="Email ID" placeholder="" type='text'></Input>
+  <Input onSetData={setSignUpData} name='email' text="Email ID" placeholder="Enter Email Address" type='text'></Input>
   <div className='relative'>
             <Input
               onSetData={setSignUpData}


### PR DESCRIPTION
I added the Email field placeholder int he signup page .
closes : #207 
![Screenshot 2024-05-29 181442](https://github.com/SamarthKadam/ChatBox/assets/118350936/c06a1f55-edd8-4a43-8e23-d9cbc98d9c06)
